### PR TITLE
Updated helper references to Ghost v1.6.0 to enable successful import to Ghost(Pro)

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -2,7 +2,7 @@
 {{!-- The tag above means - insert everything in this file into the {body} of the default.hbs template --}}
 
 {{!-- The big featured header --}}
-<header class="{{#if @blog.cover}}" style="background-image: url({{@blog.cover}}){{else}}no-cover{{/if}}">
+<header class="{{#if @blog.cover_image}}" style="background-image: url({{@blog.cover_image}}){{else}}no-cover{{/if}}">
     <nav class="">
         {{#if @blog.logo}}<a class="" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
         {{#if @blog.navigation}}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "Inextinguishable",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Importing 1.0.0 into Ghost(Pro) generated the following fatal errors. Updated helper references so import would succeed.

* Replace the {{@blog.cover}} helper with {{@blog.cover_image}}
  * Affected files:
    * index.hbs: Please remove or replace {{@blog.cover}} from this template
* Replace the {{#if @blog.cover}} helper with {{#if @blog.cover_image}}
  * Affected files:
    * index.hbs: Please remove or replace {{#if @blog.cover}} from this template